### PR TITLE
Update api/js/pdok-api.js

### DIFF
--- a/api/js/pdok-api.js
+++ b/api/js/pdok-api.js
@@ -733,6 +733,9 @@ Pdok.Api.prototype.createOlMap = function() {
     // add marker and use markertype if given, otherwise the default marker
     // backward compatibility: mloc is alway point
     if (this.mloc != null) {
+        if(typeof this.mloc == 'string'){
+            this.mloc = this.mloc.replace(' ', '').split(',');
+        }
         var wkt = 'POINT('+this.mloc[0]+' '+this.mloc[1]+')';
         if (this.mt==null){
             this.mt='mt0'; // mt0 is default point symbol


### PR DESCRIPTION
mloc string split toegevoegd op regels 736,737,738. Dit lost bug op als er maar 1 marker is gemaakt en via config = {"mloc":'118845.6,455190.918125',"mt":'mt0'} wordt aangeroepen.
