### PR TITLE
fix buggy highlighting, remove obsolete link

### DIFF
--- a/help.html
+++ b/help.html
@@ -42,9 +42,9 @@
                         <li>
                             <a href=".">Home</a>
                         </li>
-                        <li>
+                        <!-- <li>
                             <a href="index.html">PDOK Wizard</a>
-                        </li>
+                        </li> -->
                         <li class="sel">
                             <a class="active" href="help.html">Help</a>
                         </li>

--- a/index.html
+++ b/index.html
@@ -90,14 +90,14 @@
                 </div>
                 <div class="nav_bar">
                     <ul class="nav_main">
-                        <li>
-                            <a href=".">Home</a>
-                        </li>
-                        <li>
-                            <a href="index.html">PDOK Wizard</a>
-                        </li>
                         <li class="sel">
-                            <a class="active" href="help.html">Help</a>
+                            <a class="active" href=".">Home</a>
+                        </li>
+                        <!-- <li>
+                            <a href="index.html">PDOK Wizard</a>
+                        </li> -->
+                        <li>
+                            <a href="help.html">Help</a>
                         </li>
                     </ul>
                 </div>


### PR DESCRIPTION
Fix voor #180 /cc @beheerPDOK

Ik heb `PDOK Wizard` knop verwijdert omdat ie hetzelfde doet als `Home`